### PR TITLE
Fix copy_hex

### DIFF
--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -19,10 +19,22 @@ function copy_hex() {
   mkdir -p ${build_path}/.mix/archives
   mkdir -p ${build_path}/.hex
 
-  hex_file=`basename ${hex_source:-hex.ez}`
+  if [ -n "$hex_source" ]; then
+    hex_file=`basename ${hex_source}`
+  else
+    # hex file names after elixir-1.1 in the hex-<version>.ez form
+    full_hex_file_path=$(ls -t ${HOME}/.mix/archives/hex-*.ez | head -n 1)
+
+    # For older versions of hex which have no version name in file
+    if [ -z "$full_hex_file_path" ]; then
+      full_hex_file_path=${HOME}/.mix/archives/hex.ez
+    fi
+  fi
 
   cp ${HOME}/.hex/registry.ets ${build_path}/.hex/
-  cp ${HOME}/.mix/archives/${hex_file} ${build_path}/.mix/archives
+
+  output_section "Copying hex from $full_hex_file_path"
+  cp $full_hex_file_path ${build_path}/.mix/archives
 }
 
 


### PR DESCRIPTION
Hex file names after elixir-1.1 in the hex-<version>.ez form
